### PR TITLE
Add a separate function for date and time components

### DIFF
--- a/Sources/FazeKit/Classes/DateAdditions.swift
+++ b/Sources/FazeKit/Classes/DateAdditions.swift
@@ -35,6 +35,11 @@ public extension Date {
         return (Calendar.current as NSCalendar).components(units, from: self)
     }
     
+    func dateAndTimeComponents() -> DateComponents {
+        let units: NSCalendar.Unit = [.year, .month, .day, .hour, .minute, .second]
+        return (Calendar.current as NSCalendar).components(units, from: self)
+    }
+    
     static func dateFromComponents(day: Int? = nil,
                                    month: Int? = nil,
                                    year: Int? = nil,


### PR DESCRIPTION
There is a `dateComponents()` and `timeComponents()` function.

Now there is also a .... `dateAndTimeComponents()` function.

